### PR TITLE
[METAED-1364] Publish to VS Marketplace

### DIFF
--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -9,6 +9,9 @@ on:
     types:
       - prereleased
 
+env:
+  GITHUB_TOKEN: ${{ secrets.ATTACH_TO_RELEASE }}
+
 jobs:
   package:
     name: Build VSIX Package
@@ -84,4 +87,33 @@ jobs:
           name: vscode-metaed.vsix
           path: vscode-metaed.vsix
           sha256: "${{ needs.package.outputs.hash-code }}"
+
+      - name: Attach to release
+        shell: pwsh
+        run: |
+          $release = "${{ github.ref_name }}"
+          $repo = "${{ github.repository }}"
+          $token = "${{ env.GITHUB_TOKEN }}"
+          $file = "vscode-metaed.vsix"
+          $uploadName = "vscode-metaed.vsix"
+
+          $url = "https://api.github.com/repos/$repo/releases/tags/$release"
+
+          $gh_headers = @{
+              "Accept"        = "application/vnd.github+json"
+              "Authorization" = "Bearer $token"
+          }
+
+          $response = Invoke-RestMethod -Uri $url -Headers $gh_headers
+          $releaseId = $response.id
+
+          $url = "https://uploads.github.com/repos/$repo/releases/$releaseId/assets"
+
+          Compress-Archive $file -DestinationPath $uploadName
+
+          $gh_headers["Content-Type"] = "application/octet"
+          Invoke-RestMethod -Method POST `
+              -Uri "$($url)?name=$($uploadName)" `
+              -Headers $gh_headers `
+              -InFile $uploadName
 

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -94,7 +94,6 @@ jobs:
           $release = "${{ github.ref_name }}"
           $repo = "${{ github.repository }}"
           $token = "${{ env.GITHUB_TOKEN }}"
-          $file = "vscode-metaed.vsix"
           $uploadName = "vscode-metaed.vsix"
 
           $url = "https://api.github.com/repos/$repo/releases/tags/$release"
@@ -108,8 +107,6 @@ jobs:
           $releaseId = $response.id
 
           $url = "https://uploads.github.com/repos/$repo/releases/$releaseId/assets"
-
-          Compress-Archive $file -DestinationPath $uploadName
 
           $gh_headers["Content-Type"] = "application/octet"
           Invoke-RestMethod -Method POST `

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -82,7 +82,7 @@ jobs:
       contents: write
     steps:
       - name: Securely retrieve the package from artifacts
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@1d646d70aeba1516af69fb0ef48206580122449b
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@7f4fdb8  # v1.5.0
         with:
           name: vscode-metaed.vsix
           path: vscode-metaed.vsix

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: On Pre-Release
+on:
+  release:
+    types:
+      - prereleased
+
+jobs:
+  package:
+    name: Build VSIX Package
+    runs-on: ubuntu-latest
+    outputs:
+      hash-code: ${{ steps.hash-code.outputs.hash-code }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      - name: Setup Node
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
+        with:
+          node-version: "16"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Node modules cache
+        id: modules-cache
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
+        run: npm install
+
+      - name: Load prior build from cache if available
+        id: build-cache
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
+        with:
+          path: "**/dist/**"
+          key: ${{ runner.os }}-build-${{ hashFiles('**/dist/**') }}
+
+      - name: Build Typescript
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        run: npm run build
+
+      - name: Install vsce
+        run: npm install --global @vscode/vsce
+
+      - name: Build vsix package
+        run: |
+          npm run package:clean
+          npm run package:vsce
+
+      - name: Generate hash code for VSIX file
+        id: hash-code
+        run: |
+          # sha256sum returns "<hashcode>  <name of file". Split that and return only the <hashcode>.
+          hash=$(sha256sum ./extensions/vscode-metaed.vsix | awk '{split($0,a); print a[1]}')
+          echo "hash-code=$hash" >> $GITHUB_OUTPUT
+
+      - name: Upload vsix package
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        with:
+          name: vscode-metaed.vsix
+          path: extension/vscode-metaed.vsix
+          retention-days: 1
+
+  packages-attach:
+    name: Attach Package to Release
+    runs-on: ubuntu-latest
+    needs: pack
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Securely retrieve the package from artifacts
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@1d646d70aeba1516af69fb0ef48206580122449b
+        with:
+          name: vscode-metaed.vsix
+          path: vscode-metaed.vsix
+          sha256: "${{ needs.package.outputs.hash-code }}"
+

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -82,7 +82,7 @@ jobs:
       contents: write
     steps:
       - name: Securely retrieve the package from artifacts
-        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@7f4fdb8  # v1.5.0
+        uses: slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact@7f4fdb871876c23e455853d694197440c5a91506  # v1.5.0
         with:
           name: vscode-metaed.vsix
           path: vscode-metaed.vsix

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -73,7 +73,7 @@ jobs:
   packages-attach:
     name: Attach Package to Release
     runs-on: ubuntu-latest
-    needs: pack
+    needs: package
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -10,7 +10,7 @@ on:
       - prereleased
 
 env:
-  GITHUB_TOKEN: ${{ secrets.ATTACH_TO_RELEASE }}
+  GITHUB_TOKEN: ${{ secrets.PAT_ATTACH_TO_RELEASE }}
 
 jobs:
   package:

--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -60,7 +60,7 @@ jobs:
         id: hash-code
         run: |
           # sha256sum returns "<hashcode>  <name of file". Split that and return only the <hashcode>.
-          hash=$(sha256sum ./extensions/vscode-metaed.vsix | awk '{split($0,a); print a[1]}')
+          hash=$(sha256sum ./extension/vscode-metaed.vsix | awk '{split($0,a); print a[1]}')
           echo "hash-code=$hash" >> $GITHUB_OUTPUT
 
       - name: Upload vsix package

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -18,19 +18,6 @@ jobs:
     name: Scan Actions
     uses: ed-fi-alliance-oss/ed-fi-actions/.github/workflows/repository-scanner.yml@main
 
-  analyze-code:
-    if: github.event_name == 'pull_request'
-    name: Analyze Code Dependencies
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -61,7 +48,7 @@ jobs:
         run: npm run test:lint
 
   build:
-    name: Build
+    name: Build and Code Security
     runs-on: ubuntu-latest
 
     steps:
@@ -86,6 +73,15 @@ jobs:
         if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
         run: npm install
 
+      - name: Dependency Review ("Dependabot on PR")
+        uses: actions/dependency-review-action@a9c83d3af6b9031e20feba03b904645bb23d1dab # v1.0.2
+
+      - name: Initialize CodeQL
+        if: success()
+        uses: github/codeql-action/init@1fae5bf71b0ecdc7d0a2ef0d0c28409d99693966 # v2.9.2
+        with:
+          languages: javascript
+
       - name: Build Cache
         id: build-cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
@@ -97,15 +93,19 @@ jobs:
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         run: npm run build
 
+      - name: Perform CodeQL Analysis
+        if: success()
+        uses: github/codeql-action/analyze@1fae5bf71b0ecdc7d0a2ef0d0c28409d99693966 # v2.9.2
+
       - name: Install vsce
         run: npm install --global @vscode/vsce
 
       - name: Build vsix package
-        run: vsce package --allow-star-activation --allow-missing-repository --out vscode-metaed.vsix
+        run: npm run package:vsce
 
       - name: Upload vsix package
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: vscode-metaed.vsix
-          path: vscode-metaed.vsix
+          path: extension/vscode-metaed.vsix
           retention-days: 10

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -103,7 +103,9 @@ jobs:
         run: npm install --global @vscode/vsce
 
       - name: Build vsix package
-        run: npm run package:vsce
+        run: |
+          npm run package:clean
+          npm run package:vsce
 
       - name: Upload vsix package
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -74,6 +74,8 @@ jobs:
         run: npm install
 
       - name: Dependency Review ("Dependabot on PR")
+        # This action can only run in pull requests
+        if: ${{ github.event.pull_request }}
         uses: actions/dependency-review-action@a9c83d3af6b9031e20feba03b904645bb23d1dab # v1.0.2
 
       - name: Initialize CodeQL

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-        
+
       - name: Install vsce
         run: npm install --global @vscode/vsce
 
@@ -55,4 +55,4 @@ jobs:
           Invoke-RestMethod -Uri $url -Outfile $file
 
       - name: Publish to the marketplace
-        run: npx vsce publish --allow-star-activation          
+        run: npx vsce publish --allow-star-activation --packagePath vscode-metaed.vsix        

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -18,6 +18,9 @@ jobs:
     name: Publish VSIX to Visual Studio Marketplace
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        
       - name: Install vsce
         run: npm install --global @vscode/vsce
 

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -11,7 +11,7 @@ on:
       - released
 
 env:
-  VS_MARKETPLACE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.ATTACH_TO_RELEASE }}
   VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
 jobs:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -11,7 +11,6 @@ on:
       - released
 
 env:
-  GITHUB_TOKEN: ${{ secrets.ATTACH_TO_RELEASE }}
   VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
 jobs:
@@ -25,35 +24,32 @@ jobs:
       - name: Retrieve VSIX from release
         shell: pwsh
         run: |
-          $releaseId = "${{ github.ref_name }}"
+          $tag = "${{ github.ref_name }}"
           $repo = "${{ github.repository }}"
-          $token = "${{ env.GITHUB_TOKEN }}"
           $file = "vscode-metaed.vsix"
 
           # Get a list of assets
-          $url = "https://api.github.com/repos/$repo/releases/$releaseId/assets"
+          $url = "https://api.github.com/repos/$repo/releases"
 
-          $gh_headers = @{
-              "Accept"        = "application/vnd.github+json"
-              "Authorization" = "Bearer $token"
+          $response = Invoke-RestMethod -Uri $url
+
+          $response | 
+            Where-Object { $_.name -eq $tag } |
+            Where-Object { $_.assets}
+          
+          try {
+            $url = $response |
+              Where-Object { $_.name -eq $tag } |
+              Select-Object -ExpandProperty assets |
+              Where-Object { $_.name -eq $file } |
+              Select-Object -ExpandProperty browser_download_url
+          }
+          catch {
+            Write-Output "::error Did not find $file in the list of assets"
+            exit 1
           }
 
-          $response = Invoke-RestMethod -Uri $url -Headers $gh_headers         
-
-          $response | ForEach-Object {
-              if ($_.name -eq $file) {
-                  $uri = $_.browswer_download_url
-
-                  Invoke-RestMethod -Uri $uri -OutFile ./$file
-
-                  return
-              }
-          }
-
-          Write-Output "::error Did not find $file in the list of assets"
-          exit -1
+          Invoke-RestMethod -Uri $url -Outfile $file
 
       - name: Publish to the marketplace
-        run: npx vsce publish --allow-star-activation
-          
-
+        run: npx vsce publish --allow-star-activation          

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: On Release
+
+on:
+  release:
+    types:
+      - released
+
+env:
+  VS_MARKETPLACE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+jobs:
+  publish:
+    name: Publish VSIX to Visual Studio Marketplace
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install vsce
+        run: npm install --global @vscode/vsce
+
+      - name: Retrieve VSIX from release
+        shell: pwsh
+        run: |
+          $releaseId = "${{ github.ref_name }}"
+          $repo = "${{ github.repository }}"
+          $token = "${{ env.GITHUB_TOKEN }}"
+          $file = "vscode-metaed.vsix"
+
+          # Get a list of assets
+          $url = "https://api.github.com/repos/$repo/releases/$releaseId/assets"
+
+          $gh_headers = @{
+              "Accept"        = "application/vnd.github+json"
+              "Authorization" = "Bearer $token"
+          }
+
+          $response = Invoke-RestMethod -Uri $url -Headers $gh_headers         
+
+          $response | ForEach-Object {
+              if ($_.name -eq $file) {
+                  $uri = $_.browswer_download_url
+
+                  Invoke-RestMethod -Uri $uri -OutFile ./$file
+
+                  return
+              }
+          }
+
+          Write-Output "::error Did not find $file in the list of assets"
+          exit -1
+
+      - name: Publish to the marketplace
+        run: npx vsce publish --allow-star-activation
+          
+

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "MetaEd IDE",
 	"description": "Ed-Fi MetaEd IDE for Visual Studio Code",
 	"license": "SEE LICENSE IN LICENSE.md",
-	"version": "0.0.1",
+	"version": "0.0.3",
 	"publishConfig": {
 		"registry": "https://www.myget.org/F/ed-fi/npm/"
 	},


### PR DESCRIPTION
How it works:

* Create a release in GitHub named with the proper tag (e.g. `v1.0.0`) and save *as a pre-release*
* Wait a minute or two for the `on-prerelease.yml` workflow to run. It:
  * Generates a new VSIX
  * Attaches it as an asset on the release
* Download from the asset for final end-user testing
* When ready to publish to the marketplace, edit the release by changing from pre-release to *latest* release
  * The `on-release.yml` workflow downloads the VSIX asset and publishes it to Visual Studio Marketplace

Partial demonstration in my fork (I did not load the token for VS Marketplace publishing, so that final step failed).

* [Release 0.0.6](https://github.com/stephenfuqua/vscode-metaed-ide/releases/tag/v0.0.6)
* [on-prerelease workflow run](https://github.com/stephenfuqua/vscode-metaed-ide/actions/runs/4346391617) 
* [on-release workflow run](https://github.com/stephenfuqua/vscode-metaed-ide/actions/runs/4346560187)