### PR TITLE
 [METAED-1488] Upgrade dependencies to fix Data Standard has invalid merge directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,6 @@
 			"version": "4.2.1",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@edfi/ed-fi-model-3.0": "3.0.1",
-				"@edfi/ed-fi-model-3.1": "3.0.1",
-				"@edfi/ed-fi-model-3.2a": "3.0.1",
-				"@edfi/ed-fi-model-3.2b": "3.0.1",
-				"@edfi/ed-fi-model-3.2c": "3.0.1",
-				"@edfi/ed-fi-model-3.3a": "3.0.1",
-				"@edfi/ed-fi-model-3.3b": "3.0.1",
-				"@edfi/ed-fi-model-4.0": "3.0.1",
-				"@edfi/ed-fi-model-4.0a": "3.0.3",
-				"@edfi/ed-fi-model-5.0-pre.1": "3.0.1",
-				"@edfi/ed-fi-model-5.0-pre.2": "3.0.1",
 				"@edfi/metaed-console": "4.2.1",
 				"@edfi/metaed-core": "4.2.1",
 				"@edfi/metaed-default-plugins": "4.2.1",
@@ -131,46 +120,16 @@
 			"integrity": "sha1-k72XLdRTBXSpRe9j9tBVdbe/Wqk=",
 			"license": "private"
 		},
-		"node_modules/@edfi/ed-fi-model-3.2c": {
-			"version": "3.0.1",
-			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-3.2c/-/ed-fi-model-3.2c-3.0.1.tgz",
-			"integrity": "sha1-kq84kr1phXWCMaEriOUoWd4mWK4=",
-			"license": "private"
-		},
 		"node_modules/@edfi/ed-fi-model-3.3a": {
 			"version": "3.0.1",
 			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-3.3a/-/ed-fi-model-3.3a-3.0.1.tgz",
 			"integrity": "sha1-Z1t2/0+1SXI1sZtIZSHAic3EXtg=",
 			"license": "private"
 		},
-		"node_modules/@edfi/ed-fi-model-3.3b": {
-			"version": "3.0.1",
-			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-3.3b/-/ed-fi-model-3.3b-3.0.1.tgz",
-			"integrity": "sha1-MXdRlBbwV/9sPvH2pbBIpkrtKdM=",
-			"license": "private"
-		},
-		"node_modules/@edfi/ed-fi-model-4.0": {
-			"version": "3.0.1",
-			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-4.0/-/ed-fi-model-4.0-3.0.1.tgz",
-			"integrity": "sha1-ef/mhuIwWl9YSBWPet0SuIHVby4=",
-			"license": "private"
-		},
 		"node_modules/@edfi/ed-fi-model-4.0a": {
 			"version": "3.0.3",
 			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-4.0a/-/ed-fi-model-4.0a-3.0.3.tgz",
 			"integrity": "sha1-4/flqFH2VTqMkl0Vm+V6xmpK3UI=",
-			"license": "private"
-		},
-		"node_modules/@edfi/ed-fi-model-5.0-pre.1": {
-			"version": "3.0.1",
-			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-5.0-pre.1/-/ed-fi-model-5.0-pre.1-3.0.1.tgz",
-			"integrity": "sha1-llklpfpK6wb8y2XXXpj4TGGs13M=",
-			"license": "private"
-		},
-		"node_modules/@edfi/ed-fi-model-5.0-pre.2": {
-			"version": "3.0.1",
-			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-5.0-pre.2/-/ed-fi-model-5.0-pre.2-3.0.1.tgz",
-			"integrity": "sha1-dwJDczbb6sOe3TVippKf2+UZrTg=",
 			"license": "private"
 		},
 		"node_modules/@edfi/metaed-console": {
@@ -194,6 +153,24 @@
 				"semver": "^5.7.1",
 				"yargs": "^17.6.0"
 			}
+		},
+		"node_modules/@edfi/metaed-console/node_modules/@edfi/ed-fi-model-3.2c": {
+			"version": "3.0.1",
+			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-3.2c/-/ed-fi-model-3.2c-3.0.1.tgz",
+			"integrity": "sha1-kq84kr1phXWCMaEriOUoWd4mWK4=",
+			"license": "private"
+		},
+		"node_modules/@edfi/metaed-console/node_modules/@edfi/ed-fi-model-3.3b": {
+			"version": "3.0.1",
+			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-3.3b/-/ed-fi-model-3.3b-3.0.1.tgz",
+			"integrity": "sha1-MXdRlBbwV/9sPvH2pbBIpkrtKdM=",
+			"license": "private"
+		},
+		"node_modules/@edfi/metaed-console/node_modules/@edfi/ed-fi-model-4.0": {
+			"version": "3.0.1",
+			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-4.0/-/ed-fi-model-4.0-3.0.1.tgz",
+			"integrity": "sha1-ef/mhuIwWl9YSBWPet0SuIHVby4=",
+			"license": "private"
 		},
 		"node_modules/@edfi/metaed-core": {
 			"version": "4.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
 			"version": "4.2.1",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
+				"@edfi/ed-fi-model-3.2c": "3.0.2",
+				"@edfi/ed-fi-model-3.3b": "3.0.2",
+				"@edfi/ed-fi-model-4.0": "3.0.2",
 				"@edfi/metaed-console": "4.2.1",
 				"@edfi/metaed-core": "4.2.1",
 				"@edfi/metaed-default-plugins": "4.2.1",
@@ -120,10 +123,28 @@
 			"integrity": "sha1-k72XLdRTBXSpRe9j9tBVdbe/Wqk=",
 			"license": "private"
 		},
+		"node_modules/@edfi/ed-fi-model-3.2c": {
+			"version": "3.0.2",
+			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-3.2c/-/ed-fi-model-3.2c-3.0.2.tgz",
+			"integrity": "sha1-FJpWkOGZDxbGiiF96mw0G04lbYU=",
+			"license": "private"
+		},
 		"node_modules/@edfi/ed-fi-model-3.3a": {
 			"version": "3.0.1",
 			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-3.3a/-/ed-fi-model-3.3a-3.0.1.tgz",
 			"integrity": "sha1-Z1t2/0+1SXI1sZtIZSHAic3EXtg=",
+			"license": "private"
+		},
+		"node_modules/@edfi/ed-fi-model-3.3b": {
+			"version": "3.0.2",
+			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-3.3b/-/ed-fi-model-3.3b-3.0.2.tgz",
+			"integrity": "sha1-ycBH4itwLxSXRAnBdlKwKUHXmtE=",
+			"license": "private"
+		},
+		"node_modules/@edfi/ed-fi-model-4.0": {
+			"version": "3.0.2",
+			"resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/ed-fi-model-4.0/-/ed-fi-model-4.0-3.0.2.tgz",
+			"integrity": "sha1-o7Nyv8FCy8XtHwieFZbMEYtSGl8=",
 			"license": "private"
 		},
 		"node_modules/@edfi/ed-fi-model-4.0a": {

--- a/package.json
+++ b/package.json
@@ -149,17 +149,6 @@
 		"test:lint:ts": "tsc -p . --noEmit"
 	},
 	"dependencies": {
-		"@edfi/ed-fi-model-3.0": "3.0.1",
-		"@edfi/ed-fi-model-3.1": "3.0.1",
-		"@edfi/ed-fi-model-3.2a": "3.0.1",
-		"@edfi/ed-fi-model-3.2b": "3.0.1",
-		"@edfi/ed-fi-model-3.2c": "3.0.1",
-		"@edfi/ed-fi-model-3.3a": "3.0.1",
-		"@edfi/ed-fi-model-3.3b": "3.0.1",
-		"@edfi/ed-fi-model-4.0": "3.0.1",
-		"@edfi/ed-fi-model-4.0a": "3.0.3",
-		"@edfi/ed-fi-model-5.0-pre.1": "3.0.1",
-		"@edfi/ed-fi-model-5.0-pre.2": "3.0.1",
 		"@edfi/metaed-console": "4.2.1",
 		"@edfi/metaed-core": "4.2.1",
 		"@edfi/metaed-default-plugins": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,9 @@
 		"test:lint:ts": "tsc -p . --noEmit"
 	},
 	"dependencies": {
+		"@edfi/ed-fi-model-3.2c": "3.0.2",
+		"@edfi/ed-fi-model-3.3b": "3.0.2",
+		"@edfi/ed-fi-model-4.0": "3.0.2",
 		"@edfi/metaed-console": "4.2.1",
 		"@edfi/metaed-core": "4.2.1",
 		"@edfi/metaed-default-plugins": "4.2.1",


### PR DESCRIPTION
Upgrade dependencies:
- @edfi/ed-fi-model-3.2c
- @edfi/ed-fi-model-3.3b
- @edfi/ed-fi-model-4.0

Remove dependencies:
- @edfi/ed-fi-model-3.1
- @edfi/ed-fi-model-3.2a
- @edfi/ed-fi-model-3.2b
- @edfi/ed-fi-model-3.3a
- @edfi/ed-fi-model-4.0a
- @edfi/ed-fi-model-5.0-pre.2
- @edfi/ed-fi-model-5.0-pre.1 '@edfi/ed-fi-model-5.0-pre.2